### PR TITLE
Update README.md to use async main for all sample code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ cargo run --example incidents
 
 ### Basic Client
 ```rust
-fn main() -> victorops::ApiResult<()> {
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
   let client = victorops::Client::new(
     "api-id".to_string(),
     "api-key".to_string(),
@@ -129,7 +130,8 @@ fn main() -> victorops::ApiResult<()> {
 ```rust
 use std::time::Duration;
 
-fn main() -> victorops::ApiResult<()> {
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
   let client = victorops::Client::with_timeout(
     "api-id".to_string(),
     "api-key".to_string(),


### PR DESCRIPTION
In order to be more consistent, this commit updates all code samples to
be async code blocks. This is because the library is async and code
samples should all reflect that even if they don't use anything
asynchronous in their sample code.
