### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/endoze/victorops/releases/tag/v0.1.0) - 2025-05-26
+
+### Other
+
+- Update README.md to use async main for all sample code blocks
+- Initial Commit


### PR DESCRIPTION



## 🤖 New release

* `victorops`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/endoze/victorops/releases/tag/v0.1.0) - 2025-05-26

### Other

- Update README.md to use async main for all sample code blocks
- Initial Commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).