### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/endoze/victorops/compare/v0.1.0...v0.1.1) - 2025-05-26
+
+### Other
+
+- Add badges to readme

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1498,7 +1498,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "victorops"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "mockito",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "victorops"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 authors = ["Endoze <endoze@endozemedia.com>"]
 description = "Async Rust client for VictorOps"


### PR DESCRIPTION



## 🤖 New release

* `victorops`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/endoze/victorops/compare/v0.1.0...v0.1.1) - 2025-05-26

### Other

- Add badges to readme
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).