### PR TITLE
Make Vecs in api response more ergonomic

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
   )?;
   
   let (incidents, _details) = client.get_incidents().await?;
-  println!("Found {} incidents", incidents.incidents.map_or(0, |i| i.len()));
+  println!("Found {} incidents", incidents.incidents.len());
 
   Ok(())
 }

--- a/examples/team_schedule.rs
+++ b/examples/team_schedule.rs
@@ -17,9 +17,9 @@ async fn main() -> victorops::ApiResult<()> {
 
   let (schedule, _details) = client.get_api_team_schedule(&team_slug, 7, 0, 0).await?;
 
-  if let Some(schedules) = schedule.schedules {
+  if !schedule.schedules.is_empty() {
     println!("Team Schedule for '{}':", team_slug);
-    println!("{:#?}", schedules);
+    println!("{:#?}", schedule.schedules);
   } else {
     println!("No schedules found for team '{}'", team_slug);
   }

--- a/src/client.rs
+++ b/src/client.rs
@@ -568,8 +568,8 @@ impl Client {
   ) -> ApiResult<(bool, RequestDetails)> {
     let (members, details) = self.get_team_members(team_id).await?;
 
-    if let Some(member_list) = members.members {
-      for member in member_list {
+    if !members.members.is_empty() {
+      for member in &members.members {
         if let Some(member_username) = &member.username {
           if member_username.to_lowercase() == username.to_lowercase() {
             return Ok((true, details));
@@ -861,11 +861,11 @@ impl Client {
   ) -> ApiResult<(Option<RoutingKeyResponse>, RequestDetails)> {
     let (rk_list, details) = self.get_all_routing_keys().await?;
 
-    if let Some(routing_keys) = rk_list.routing_keys {
-      for key in routing_keys {
+    if !rk_list.routing_keys.is_empty() {
+      for key in &rk_list.routing_keys {
         if let Some(routing_key) = &key.routing_key {
           if routing_key == key_name {
-            return Ok((Some(key), details));
+            return Ok((Some(key.clone()), details));
           }
         }
       }
@@ -1083,11 +1083,11 @@ impl Client {
 
     let contacts: GetAllContactResponse = serde_json::from_str(&details.response_body)?;
 
-    if let Some(contact_methods) = contacts.contact_methods {
-      for contact in contact_methods {
+    if !contacts.contact_methods.is_empty() {
+      for contact in &contacts.contact_methods {
         if let Some(contact_id) = contact.id {
           if contact_id == id {
-            return Ok((Some(contact), details));
+            return Ok((Some(contact.clone()), details));
           }
         }
       }
@@ -1268,8 +1268,8 @@ mod tests {
     assert!(result.is_ok());
 
     let (incident_response, details) = result.unwrap();
-    assert!(incident_response.incidents.is_some());
-    let incidents = incident_response.incidents.unwrap();
+    assert!(!incident_response.incidents.is_empty());
+    let incidents = &incident_response.incidents;
     assert_eq!(incidents.len(), 2);
     assert_eq!(details.status_code, 200);
   }
@@ -1973,8 +1973,8 @@ mod tests {
     assert!(result.is_ok());
 
     let (team_members, details) = result.unwrap();
-    assert!(team_members.members.is_some());
-    let members = team_members.members.unwrap();
+    assert!(!team_members.members.is_empty());
+    let members = &team_members.members;
     assert_eq!(members.len(), 2);
     assert_eq!(details.status_code, 200);
   }
@@ -2011,8 +2011,8 @@ mod tests {
     assert!(result.is_ok());
 
     let (team_members, details) = result.unwrap();
-    assert!(team_members.admin.is_some());
-    let members = team_members.admin.unwrap();
+    assert!(!team_members.admin.is_empty());
+    let members = &team_members.admin;
     assert_eq!(members.len(), 1);
     assert_eq!(details.status_code, 200);
   }
@@ -2059,7 +2059,7 @@ mod tests {
     assert!(result.is_ok());
 
     let (schedule, details) = result.unwrap();
-    assert!(schedule.schedules.is_some());
+    assert!(!schedule.schedules.is_empty());
     assert_eq!(details.status_code, 200);
   }
 
@@ -2098,7 +2098,7 @@ mod tests {
     assert!(result.is_ok());
 
     let (schedule, details) = result.unwrap();
-    assert!(schedule.schedules.is_some());
+    assert!(schedule.schedules.is_empty());
     assert_eq!(details.status_code, 200);
   }
 
@@ -2148,7 +2148,7 @@ mod tests {
     assert!(result.is_ok());
 
     let (schedule, details) = result.unwrap();
-    assert!(schedule.schedules.is_some());
+    assert!(!schedule.schedules.is_empty());
     assert_eq!(details.status_code, 200);
   }
 
@@ -2409,7 +2409,7 @@ mod tests {
 
     let routing_key = crate::types::RoutingKey {
       routing_key: Some("test-key".to_string()),
-      targets: Some(vec!["team1".to_string(), "team2".to_string()]),
+      targets: vec!["team1".to_string(), "team2".to_string()],
     };
 
     let result = client.create_routing_key(&routing_key).await;
@@ -2463,8 +2463,8 @@ mod tests {
     assert!(result.is_ok());
 
     let (routing_keys, details) = result.unwrap();
-    assert!(routing_keys.routing_keys.is_some());
-    let keys = routing_keys.routing_keys.unwrap();
+    assert!(!routing_keys.routing_keys.is_empty());
+    let keys = &routing_keys.routing_keys;
     assert_eq!(keys.len(), 2);
     assert_eq!(details.status_code, 200);
   }

--- a/src/types.rs
+++ b/src/types.rs
@@ -100,25 +100,25 @@ pub struct Incident {
   #[serde(skip_serializing_if = "Option::is_none", rename = "startTime")]
   pub start_time: Option<DateTime<Utc>>,
   /// The list of teams that were paged for this incident.
-  #[serde(skip_serializing_if = "Option::is_none", rename = "pagedTeams")]
-  pub paged_teams: Option<Vec<String>>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty", rename = "pagedTeams")]
+  pub paged_teams: Vec<String>,
   /// The list of users that were paged for this incident.
-  #[serde(skip_serializing_if = "Option::is_none", rename = "pagedUsers")]
-  pub paged_users: Option<Vec<String>>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty", rename = "pagedUsers")]
+  pub paged_users: Vec<String>,
   /// The list of escalation policies that were triggered for this incident.
-  #[serde(skip_serializing_if = "Option::is_none", rename = "pagedPolicies")]
-  pub paged_policies: Option<Vec<PagedPolicy>>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty", rename = "pagedPolicies")]
+  pub paged_policies: Vec<PagedPolicy>,
   /// The state transitions that occurred during this incident.
-  #[serde(skip_serializing_if = "Option::is_none")]
-  pub transitions: Option<Vec<Transition>>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub transitions: Vec<Transition>,
 }
 
 /// Response containing a list of incidents.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IncidentResponse {
   /// The list of incidents in the response.
-  #[serde(skip_serializing_if = "Option::is_none")]
-  pub incidents: Option<Vec<Incident>>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub incidents: Vec<Incident>,
 }
 
 /// Represents a user in VictorOps.
@@ -194,8 +194,8 @@ pub struct Team {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TeamMembers {
   /// The list of team members.
-  #[serde(skip_serializing_if = "Option::is_none")]
-  pub members: Option<Vec<User>>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub members: Vec<User>,
 }
 
 /// Represents an admin user.
@@ -219,8 +219,8 @@ pub struct Admin {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TeamAdmins {
   /// The list of team administrators.
-  #[serde(skip_serializing_if = "Option::is_none")]
-  pub admin: Option<Vec<Admin>>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub admin: Vec<Admin>,
 }
 
 /// Represents a contact method.
@@ -329,8 +329,8 @@ pub struct ApiOnCallEntry {
   #[serde(skip_serializing_if = "Option::is_none", rename = "shiftRoll")]
   pub shift_roll: Option<DateTime<Utc>>,
   /// The list of rolls/rotations for this entry.
-  #[serde(skip_serializing_if = "Option::is_none")]
-  pub rolls: Option<Vec<ApiOnCallRoll>>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub rolls: Vec<ApiOnCallRoll>,
 }
 
 /// Represents an escalation policy schedule.
@@ -340,11 +340,11 @@ pub struct ApiEscalationPolicySchedule {
   #[serde(skip_serializing_if = "Option::is_none")]
   pub policy: Option<ApiEscalationPolicy>,
   /// The schedule entries for this escalation policy.
-  #[serde(skip_serializing_if = "Option::is_none")]
-  pub schedule: Option<Vec<ApiOnCallEntry>>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub schedule: Vec<ApiOnCallEntry>,
   /// The on-call overrides for this escalation policy.
-  #[serde(skip_serializing_if = "Option::is_none")]
-  pub overrides: Option<Vec<ApiOnCallOverride>>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub overrides: Vec<ApiOnCallOverride>,
 }
 
 /// Represents a team's on-call schedule.
@@ -354,16 +354,16 @@ pub struct ApiTeamSchedule {
   #[serde(skip_serializing_if = "Option::is_none")]
   pub team: Option<ApiTeam>,
   /// The escalation policy schedules for this team.
-  #[serde(skip_serializing_if = "Option::is_none")]
-  pub schedules: Option<Vec<ApiEscalationPolicySchedule>>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub schedules: Vec<ApiEscalationPolicySchedule>,
 }
 
 /// Represents a user's on-call schedule.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApiUserSchedule {
   /// The team schedules for this user.
-  #[serde(skip_serializing_if = "Option::is_none", rename = "teamSchedules")]
-  pub schedules: Option<Vec<ApiTeamSchedule>>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty", rename = "teamSchedules")]
+  pub schedules: Vec<ApiTeamSchedule>,
 }
 
 /// Request to take on-call duty.
@@ -467,8 +467,8 @@ pub struct RoutingKey {
   #[serde(skip_serializing_if = "Option::is_none", rename = "routingKey")]
   pub routing_key: Option<String>,
   /// The list of targets that this routing key routes to.
-  #[serde(skip_serializing_if = "Option::is_none")]
-  pub targets: Option<Vec<String>>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub targets: Vec<String>,
 }
 
 /// Represents targets in a routing key response.
@@ -486,16 +486,16 @@ pub struct RoutingKeyResponse {
   #[serde(skip_serializing_if = "Option::is_none", rename = "routingKey")]
   pub routing_key: Option<String>,
   /// The targets that this routing key routes to.
-  #[serde(skip_serializing_if = "Option::is_none")]
-  pub targets: Option<Vec<RoutingKeyResponseTargets>>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub targets: Vec<RoutingKeyResponseTargets>,
 }
 
 /// Response containing a list of routing keys.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RoutingKeyResponseList {
   /// The list of routing keys.
-  #[serde(skip_serializing_if = "Option::is_none", rename = "routingKeys")]
-  pub routing_keys: Option<Vec<RoutingKeyResponse>>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty", rename = "routingKeys")]
+  pub routing_keys: Vec<RoutingKeyResponse>,
 }
 
 /// Types of contact methods available in VictorOps.
@@ -598,8 +598,8 @@ pub struct AllContactResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GetAllContactResponse {
   /// The list of contact methods of the requested type.
-  #[serde(skip_serializing_if = "Option::is_none", rename = "contactMethods")]
-  pub contact_methods: Option<Vec<Contact>>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty", rename = "contactMethods")]
+  pub contact_methods: Vec<Contact>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
In order to ensure a simpler api, this commit updates all Option<Vec>
fields to instead be Vec. This allows us to just have an empty Vec when
the response doesn't include any data. Because of this change, it's one
less level of option we have to deal with and it lends itself to a more
ergonomic api. It's easier to think of a list always existing even if
it's empty vs a list that may exist or not.
