### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/endoze/victorops/compare/v0.1.1...v0.1.2) - 2025-05-27
+
+### Other
+
+- Make Vecs in api response more ergonomic
+
 ## [0.1.1](https://github.com/endoze/victorops/compare/v0.1.0...v0.1.1) - 2025-05-26
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1498,7 +1498,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "victorops"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "mockito",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "victorops"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 authors = ["Endoze <endoze@endozemedia.com>"]
 description = "Async Rust client for VictorOps"


### PR DESCRIPTION



## 🤖 New release

* `victorops`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/endoze/victorops/compare/v0.1.1...v0.1.2) - 2025-05-27

### Other

- Make Vecs in api response more ergonomic
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).