### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/endoze/victorops/compare/v0.1.3...v0.1.4) - 2026-07-20
+
+### Other
+
+- *(deps)* upgrade dependencies to latest
+
 ## [0.1.3](https://github.com/endoze/victorops/compare/v0.1.2...v0.1.3) - 2025-06-14
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1660,7 +1660,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "victorops"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "chrono",
  "mockito",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "victorops"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Endoze <endoze@endozemedia.com>"]


### PR DESCRIPTION



## 🤖 New release

* `victorops`: 0.1.3 -> 0.1.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/endoze/victorops/compare/v0.1.3...v0.1.4) - 2026-07-20

### Other

- *(deps)* upgrade dependencies to latest
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).